### PR TITLE
Remove absolute path from cache image path

### DIFF
--- a/core/components/phpthumbon/model/phpthumbon/phpthumbon.class.php
+++ b/core/components/phpthumbon/model/phpthumbon/phpthumbon.class.php
@@ -270,7 +270,7 @@ class phpThumbOn {
             $assets = ltrim($this->_config['assetsUrl'],'/');
             $imgDir = $this->_config['imagesFolder'];
 			
-            $this->_config['relativePath'] = preg_replace("#^({$full_assets}|(/)?{$assets})(/)?{$imgDir}(/)?#", '', $this->_pathinfo('dirname'));
+            $this->_config['relativePath'] = preg_replace("#^({$full_assets}|(/)?{$assets})(/)?{$imgDir}(/)?|".MODX_BASE_PATH."#", '', $this->_pathinfo('dirname'));
         }else{
             if($this->_flag = file_exists($this->_config['noimage'])){
                 $this->_config['input'] = $this->_config['noimage'];


### PR DESCRIPTION
После предыдущих изменений для работы с ajax немного неверно генерируется путь в кэш директории.

Исправляем.
